### PR TITLE
Update extractServerDetails.ts to extract version information correctly

### DIFF
--- a/utils/extractServerDetails.ts
+++ b/utils/extractServerDetails.ts
@@ -30,7 +30,7 @@ export const extractServerDetails = (data: Buffer) => {
       .contents()
       .first()
       .text(),
-    version: extractValue(stringData, "Version: ", "&nbsp;")
+    version: $("unraid-user-profile").attr("server")?.match(/"osVersion":"(.*?)"/)?.[1] || ""
   };
 
   return details;


### PR DESCRIPTION
I updated the file to extract version information correctly. I tested in my server by editing this file directly in the container, and restarting the container. Let me know if you require any more information. I am on 6.12.6
Here is the updated attributes data in HA, after making this change:
<img width="441" alt="image" src="https://github.com/BoKKeR/UnraidAPI-RE/assets/26095571/c2d02d75-115e-43c3-a13a-f027c1ea5028">
